### PR TITLE
Readmaterialprofile

### DIFF
--- a/accuread.py
+++ b/accuread.py
@@ -286,6 +286,7 @@ class ReadART(object):
                         pass
                     elif line.startswith('Layer '):
                         layer += 1
+                        mp[run].append([])
                         mp[run][layer].append(dict())
                         pass
                     elif line.startswith('Bottom depth'):

--- a/accuread.py
+++ b/accuread.py
@@ -47,7 +47,7 @@ class ReadART(object):
 
     def __init__(self,expname,basefolder='./',direct=False,
                  runvarfile=None, scalar=False,iops=False,
-                 radiance=False,sine=False):
+                 radiance=False,sine=False,material_profile=False):
         '''See PyAccu for description of arguments.'''
 
         self.has_direct = False
@@ -110,6 +110,10 @@ class ReadART(object):
             self.has_iops = True
             iops_path = os.path.join(basefolder, outputfolder, 'iops.txt')
             self.iops = self.readiops(iops_path)
+
+        if material_profile:
+            mp_path = os.path.join(basefolder,outputfolder,'material_profile.txt')
+            self.material_profile = self.read_material_profile(mp_path)
 
 
         if isinstance(runvarfile,str):
@@ -261,7 +265,58 @@ class ReadART(object):
             return iops
                         
 
-                
+    def read_material_profile(self,filename):
+        mp = []
+        with open(filename) as MP:
+            while True:
+                line = MP.readline()
+                if line.startswith('runNo'):
+                    run = int(line.split()[1])
+                    break
+
+            while True:
+                layer = -1
+                mp.append([])
+                while True:
+                    line = MP.readline()
+                    if line.startswith('='):
+                        run = int(MP.readline().split()[1])
+                        break
+                    elif line.startswith('- -'):
+                        pass
+                    elif line.startswith('Layer '):
+                        layer += 1
+                        mp[run][layer].append(dict())
+                        pass
+                    elif line.startswith('Bottom depth'):
+                        z = float(line.split()[-2])
+                        mp[run][layer]['bottomdepth'] = z
+                    else:
+                        matname = line.replace(' ','')
+                        material = dict()
+                        conc,conctype = MP.readline().split()
+                        tau,ssa,g = [float(x) for x in MP.readline().split()]
+                        atau,btau = [float(x) for x in MP.readline().split()]
+                        a,b = [float(x) for x in MP.readline().split()]
+                        df = float(MP.readline())
+
+                        material['concentration'] = int(conc)
+                        material['concentrationtype'] = conctype[1:-1]
+                        material['opticaldepth'] = tau
+                        material['singlescatteringalbedo'] = ssa
+                        material['asymmetryfactor'] = g
+                        material['absorptionoptdep'] = atau
+                        material['scatteringoptdep'] = btau
+                        material['absorption'] = a
+                        material['scattering'] = b
+                        material['deltafitscalingfactor'] = df
+
+                        mp[run][layer][matname] = material
+
+
+
+
+
             
 
 

--- a/accuread.py
+++ b/accuread.py
@@ -273,27 +273,33 @@ class ReadART(object):
                 if line.startswith('runNo'):
                     run = int(line.split()[1])
                     break
-
+            endoffile = False
             while True:
+                if endoffile:
+                    break
                 layer = -1
                 mp.append([])
                 while True:
                     line = MP.readline()
-                    if line.startswith('='):
-                        run = int(MP.readline().split()[1])
-                        break
-                    elif line.startswith('- -'):
+                    if line.startswith('=') or \
+                       line.startswith('- -') or \
+                       line.startswith('~'):
                         pass
+                    elif len(line) == 0:
+                        endoffile = True
+                        break
+                    elif line.startswith('runNo'):
+                        run = int(line.split()[1])
+                        break
                     elif line.startswith('Layer '):
                         layer += 1
-                        mp[run].append([])
-                        mp[run][layer].append(dict())
+                        mp[run].append(dict())
                         pass
                     elif line.startswith('Bottom depth'):
                         z = float(line.split()[-2])
                         mp[run][layer]['bottomdepth'] = z
                     else:
-                        matname = line.replace(' ','')
+                        matname = line.replace(' ','').strip()
                         material = dict()
                         conc,conctype = MP.readline().split()
                         tau,ssa,g = [float(x) for x in MP.readline().split()]
@@ -301,7 +307,7 @@ class ReadART(object):
                         a,b = [float(x) for x in MP.readline().split()]
                         df = float(MP.readline())
 
-                        material['concentration'] = int(conc)
+                        material['concentration'] = float(conc)
                         material['concentrationtype'] = conctype[1:-1]
                         material['opticaldepth'] = tau
                         material['singlescatteringalbedo'] = ssa
@@ -314,11 +320,8 @@ class ReadART(object):
 
                         mp[run][layer][matname] = material
 
+        return mp
 
-
-
-
-            
 
 
     def writefile(self,filename,output=None):

--- a/tests/test_materialprofile.py
+++ b/tests/test_materialprofile.py
@@ -11,12 +11,12 @@ class TestMaterialProfile(unittest.TestCase):
 
 
     def test_Nruns(self):
-        self.assertEqual(2,len(MP))
+        self.assertEqual(2,len(self.MP))
 
     def test_atmo(self):
         for j in range(2):
             for i in range(14):
-                self.assertTrue('Atmoshphericgases' in self.MP[j][i])
+                self.assertTrue('Atmosphericgases' in self.MP[j][i])
 
     def test_water(self):
         for j in range(2):
@@ -24,13 +24,14 @@ class TestMaterialProfile(unittest.TestCase):
             self.assertTrue('WaterImpurityCCRR' in self.MP[j][14])
             
     def test_bottom(self):
-        bz = [3e5,5e5,6e5,7e5,7.6e5,8e5,8.4e5,8.8e5,9e5,
-              9.2e5,9.4e5,9.6e5,9.8e5,1e6,1.001e6]
+        bz = [30000.0,50000.0,60000.0,70000.0,76000.0,80000.0,
+              84000.0,88000.0,90000.0,92000.0,94000.0,96000.0,
+              98000.0,100000.0,100100.0]
         for i in range(15):
             self.assertTrue(bz[i]==self.MP[0][i]['bottomdepth'])
 
     def test_ccrr(self):
-        ccrr = self.MP[0][14]
+        ccrr = self.MP[0][14]['WaterImpurityCCRR']
         self.assertTrue(ccrr['concentration'] == 1)
         self.assertTrue(ccrr['concentrationtype'] == 'sf')
         self.assertTrue(ccrr['opticaldepth'] == 12.54)

--- a/tests/test_materialprofile.py
+++ b/tests/test_materialprofile.py
@@ -1,0 +1,43 @@
+import numpy as np
+import unittest
+from accuread import ReadART
+
+class TestMaterialProfile(unittest.TestCase):
+
+    def setUp(self):
+        self.PA = ReadART('demo1',basefolder='tests/testdata',
+            material_profile=True,runvarfile='sza.txt')
+        self.MP = self.PA.material_profile
+
+
+    def test_Nruns(self):
+        self.assertEqual(2,len(MP))
+
+    def test_atmo(self):
+        for j in range(2):
+            for i in range(14):
+                self.assertTrue('Atmoshphericgases' in self.MP[j][i])
+
+    def test_water(self):
+        for j in range(2):
+            self.assertTrue('Purewater' in self.MP[j][14])
+            self.assertTrue('WaterImpurityCCRR' in self.MP[j][14])
+            
+    def test_bottom(self):
+        bz = [3e5,5e5,6e5,7e5,7.6e5,8e5,8.4e5,8.8e5,9e5,
+              9.2e5,9.4e5,9.6e5,9.8e5,1e6,1.001e6]
+        for i in range(15):
+            self.assertTrue(bz[i]==self.MP[0][i]['bottomdepth'])
+
+    def test_ccrr(self):
+        ccrr = self.MP[0][14]
+        self.assertTrue(ccrr['concentration'] == 1)
+        self.assertTrue(ccrr['concentrationtype'] == 'sf')
+        self.assertTrue(ccrr['opticaldepth'] == 12.54
+        self.assertTrue(ccrr['singlescatterinaglbedo'] == 0.7231
+        self.assertTrue(ccrr['asymmetryfactor'] ==  0.8402
+        self.assertTrue(ccrr['absorptionoptdep'] == 3.474
+        self.assertTrue(ccrr['scatteringoptdep'] == 9.07
+        self.assertTrue(ccrr['absorption'] == 0.03474
+        self.assertTrue(ccrr['scattering'] == 0.0907
+        self.assertTrue(ccrr['deltafitscalingfactor'] == 0.2619

--- a/tests/test_materialprofile.py
+++ b/tests/test_materialprofile.py
@@ -33,11 +33,11 @@ class TestMaterialProfile(unittest.TestCase):
         ccrr = self.MP[0][14]
         self.assertTrue(ccrr['concentration'] == 1)
         self.assertTrue(ccrr['concentrationtype'] == 'sf')
-        self.assertTrue(ccrr['opticaldepth'] == 12.54
-        self.assertTrue(ccrr['singlescatterinaglbedo'] == 0.7231
-        self.assertTrue(ccrr['asymmetryfactor'] ==  0.8402
-        self.assertTrue(ccrr['absorptionoptdep'] == 3.474
-        self.assertTrue(ccrr['scatteringoptdep'] == 9.07
-        self.assertTrue(ccrr['absorption'] == 0.03474
-        self.assertTrue(ccrr['scattering'] == 0.0907
-        self.assertTrue(ccrr['deltafitscalingfactor'] == 0.2619
+        self.assertTrue(ccrr['opticaldepth'] == 12.54)
+        self.assertTrue(ccrr['singlescatteringalbedo'] == 0.7231)
+        self.assertTrue(ccrr['asymmetryfactor'] ==  0.8402)
+        self.assertTrue(ccrr['absorptionoptdep'] == 3.474)
+        self.assertTrue(ccrr['scatteringoptdep'] == 9.07)
+        self.assertTrue(ccrr['absorption'] == 0.03474)
+        self.assertTrue(ccrr['scattering'] == 0.0907)
+        self.assertTrue(ccrr['deltafitscalingfactor'] == 0.2619)


### PR DESCRIPTION
Added a method for reading in the material_profile.txt output file. 

The data structure might be open for debate, as follows for the present.

- `self.material_profile` is a list, one entry for each run
  -  `self.material_profile[0]` is a list, one entry for each layer
     - `self.material_profile[0][0]` is a `dict`, one key for each material, and `bottomdepth` in addition
        - `self.material_profile[0][0]['Atmosphericgases']` is a `dict`, one key for each of the values given in the file
        -  `self.material_profile[0][0]['bottomdepth']` is a float